### PR TITLE
Reformat available ansible-test images into a table

### DIFF
--- a/ansible-test/README.md
+++ b/ansible-test/README.md
@@ -55,6 +55,15 @@ ansible-test integration --python 3.8 --docker localhost/test-image:centos-strea
 
 ## Available images
 
-- [test-image:archlinux](https://quay.io/ansible-community/test-image:archlinux): An ArchLinux image with Python 3.10
-- [test-image:centos-stream8](https://quay.io/ansible-community/test-image:centos-stream8): A centos-stream8 image with Python 3.8 inspired by the [centos8 ansible-test image](https://github.com/ansible/distro-test-containers/blob/c4fe28818f5a33b675652637e3057bafe50039ee/centos8-test-container/Dockerfile)
-- [test-image:debian-bullseye](https://quay.io/ansible-community/test-image:debian-bullseye): A Debian Bullseye image with Python 3.9 inspired by the [ubuntu2004 ansible-test image](https://github.com/ansible/distro-test-containers/blob/c4fe28818f5a33b675652637e3057bafe50039ee/ubuntu2004-test-container/Dockerfile)
+| image             | py27 | py36 | py38 | py39 | py3.10 | Notes                                    |
+|-------------------|------|------|------|------|--------|------------------------------------------|
+| [archlinux]       |      |      |      |      |   ✔️    |                                          |
+| [centos-stream8]  |      |      |  ✔️   |      |        | Based on [centos8 ansible-test image]    |
+| [debian-bullseye] |      |      |      |  ✔️   |        | Based on [ubuntu2004 ansible-test image] |
+
+[archlinux]: https://quay.io/ansible-community/test-image:archlinux
+[centos-stream8]: https://quay.io/ansible-community/test-image:centos-stream8
+[debian-bullseye]: https://quay.io/ansible-community/test-image:debian-bullseye
+
+[centos8 ansible-test image]: https://github.com/ansible/distro-test-containers/blob/c4fe28818f5a33b675652637e3057bafe50039ee/centos8-test-container/Dockerfile
+[ubuntu2004 ansible-test image]: https://github.com/ansible/distro-test-containers/blob/c4fe28818f5a33b675652637e3057bafe50039ee/ubuntu2004-test-container/Dockerfile


### PR DESCRIPTION
This format is likely more appropriate for listing an increasing amount
of images with various versions of python.