### PR TITLE
test-ee:2.12-with-ansible5, use stable-2.12-latest for runner

### DIFF
--- a/execution-environments/2.12-with-ansible5/execution-environment.yml
+++ b/execution-environments/2.12-with-ansible5/execution-environment.yml
@@ -1,7 +1,7 @@
 ---
 version: 1
 build_arg_defaults:
-  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.12-devel'
+  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.12-latest'
 
 ansible_config: 'ansible.cfg'
 

--- a/execution-environments/README.md
+++ b/execution-environments/README.md
@@ -38,4 +38,4 @@ ansible-navigator --pull-policy never \
 
 ## Available images
 
-- [test-ee:2.12-with-ansible5](https://quay.io/ansible-community/test-ee:2.12-with-ansible5): [ansible-runner:stable-2.12-devel](https://quay.io/ansible/ansible-runner:stable-2.12-devel) with some extra packages, including ``pip install "ansible>=5,<6" ara``
+- [test-ee:2.12-with-ansible5](https://quay.io/ansible-community/test-ee:2.12-with-ansible5): [ansible-runner:stable-2.12-latest](https://quay.io/ansible/ansible-runner:stable-2.12-latest) with some extra packages, including ``pip install "ansible>=5,<6" ara``


### PR DESCRIPTION
The latest image is expected to be more stable than the devel one.