### PR TITLE
Install procps in CentOS Stream 8 to make sure ps and pkill are around

### DIFF
--- a/ansible-test/centos-stream8/dependencies.txt
+++ b/ansible-test/centos-stream8/dependencies.txt
@@ -15,6 +15,7 @@ net-tools
 openssh-clients
 openssh-server
 openssl-devel
+procps
 python38
 python38-cffi
 python38-cryptography


### PR DESCRIPTION
These tools were still available in the previous version of the image. Either procps was a (transitive) dependency of something that is installed and no longer is, or it was dropped from the base image.