### PR TITLE
Disable fail-fast in CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -14,6 +14,7 @@ jobs:
     name: 'Build ansible-test images (${{ matrix.name }} with Python ${{ matrix.python }})'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: archlinux

--- a/.github/workflows/execution-environments.yml
+++ b/.github/workflows/execution-environments.yml
@@ -14,6 +14,7 @@ jobs:
     name: 'Build EE image: ${{ matrix.name }}'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: 2.12-with-ansible5


### PR DESCRIPTION
Prevents that a broken image build kills other potentially working image builds.