### PR TITLE
Improve ansible-test images

### DIFF
--- a/ansible-test/archlinux/build.sh
+++ b/ansible-test/archlinux/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Builds a archlinux image suitable for use with ansible-test
 # Based on the centos8-stream image from this repository
-set -e
+set -ex
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 DEPENDENCIES="$(cat ${SCRIPT_DIR}/dependencies.txt | tr '\n' ' ')"

--- a/ansible-test/archlinux/build.sh
+++ b/ansible-test/archlinux/build.sh
@@ -16,6 +16,7 @@ buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3 i
 buildah run "${build}" -- /bin/bash -c "ssh-keygen -A && sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/' /etc/sudoers"
 buildah run "${build}" -- /bin/bash -c "mkdir -p /etc/ansible && echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts"
 buildah run "${build}" -- /bin/bash -c "systemctl enable sshd"
+buildah run "${build}" -- /bin/bash -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
 
 buildah config --volume /sys/fs/cgroup --volume /run/lock --volume /run --volume /tmp "${build}"
 buildah config --env container=docker "${build}"

--- a/ansible-test/centos-stream8/build.sh
+++ b/ansible-test/centos-stream8/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Builds a centos-stream8 image suitable for use with ansible-test
 # Based on https://github.com/ansible/distro-test-containers/blob/c4fe28818f5a33b675652637e3057bafe50039ee/centos8-test-container/Dockerfile
-set -e
+set -ex
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 DEPENDENCIES="$(cat ${SCRIPT_DIR}/dependencies.txt | tr '\n' ' ')"

--- a/ansible-test/debian-bullseye/build.sh
+++ b/ansible-test/debian-bullseye/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Builds a debian bullseye image suitable for use with ansible-test
 # Based on https://github.com/ansible/distro-test-containers/blob/c4fe28818f5a33b675652637e3057bafe50039ee/ubuntu2004-test-container/Dockerfile
-set -e
+set -ex
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 DEPENDENCIES="$(cat ${SCRIPT_DIR}/dependencies.txt | tr '\n' ' ')"


### PR DESCRIPTION
Improvements of the ansible-test images from https://github.com/ansible-community/images/pull/26 that apply generally.
- 4c8b16bdd40db82a04ecd300e092246fdafd9b69 echos the build commands, so one can more easily figure out where exactly the build breaks (if it does).
- aa3cd9971bd1a57c24659c6661ef1b8d2357a549 sets the timezone for the Arch Linux image to UTC. This avoids systemd asking for the timezone on stdin when starting the container with `--tty`.
