### PR TITLE
Require ansible-core 2.14.0+ for test images

### DIFF
--- a/ansible-test/README.md
+++ b/ansible-test/README.md
@@ -61,6 +61,8 @@ ansible-test integration --python 3.8 --docker localhost/test-image:centos-strea
 | [centos-stream8]  |      |      |  ✔️   |      |        | Based on [centos8 ansible-test image]    |
 | [debian-bullseye] |      |      |      |  ✔️   |        | Based on [ubuntu2004 ansible-test image] |
 
+Note that these images from only work with ansible-test from ansible-core 2.14.0 or later.
+
 [archlinux]: https://quay.io/ansible-community/test-image:archlinux
 [centos-stream8]: https://quay.io/ansible-community/test-image:centos-stream8
 [debian-bullseye]: https://quay.io/ansible-community/test-image:debian-bullseye

--- a/ansible-test/archlinux/build.sh
+++ b/ansible-test/archlinux/build.sh
@@ -17,7 +17,6 @@ buildah run "${build}" -- /bin/bash -c "ssh-keygen -A && sed -i -e 's/^\(Default
 buildah run "${build}" -- /bin/bash -c "mkdir -p /etc/ansible && echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts"
 buildah run "${build}" -- /bin/bash -c "systemctl enable sshd"
 
-buildah config --volume /sys/fs/cgroup --volume /run/lock --volume /run --volume /tmp "${build}"
 buildah config --env container=docker "${build}"
 buildah config --cmd "/usr/sbin/init" "${build}"
 buildah commit "${build}" "${1:-localhost/test-image:archlinux}"

--- a/ansible-test/centos-stream8/build.sh
+++ b/ansible-test/centos-stream8/build.sh
@@ -23,7 +23,6 @@ buildah run "${build}" -- /bin/bash -c "mkdir -p /etc/ansible && echo -e '[local
 buildah run "${build}" -- /bin/bash -c "rm -rf /usr/share/man/* /usr/share/doc/* /usr/share/fonts/*"
 buildah run "${build}" -- /bin/bash -c "find /usr/lib/locale -mindepth 1 -maxdepth 1 -type d -not \( -name 'en_US.utf8' -o -name 'POSIX' \) -exec rm -rf '{}' +"
 
-buildah config --volume /sys/fs/cgroup --volume /run --volume /tmp "${build}"
 buildah config --env container=docker "${build}"
 buildah config --cmd "/usr/sbin/init" "${build}"
 buildah commit "${build}" "${1:-localhost/test-image:centos-stream8}"

--- a/ansible-test/debian-bullseye/build.sh
+++ b/ansible-test/debian-bullseye/build.sh
@@ -21,7 +21,6 @@ buildah run "${build}" -- /bin/bash -c "sed /etc/locale.gen -i -e 's/# en_US\\.U
 buildah run "${build}" -- /bin/bash -c "locale-gen"
 buildah run "${build}" -- /bin/bash -c "update-locale LANG=en_US.UTF-8"
 
-buildah config --volume /sys/fs/cgroup --volume /run/lock --volume /run --volume /tmp "${build}"
 buildah config --env container=docker "${build}"
 buildah config --cmd "/sbin/init" "${build}"
 buildah commit "${build}" "${1:-localhost/test-image:debian-bullseye}"


### PR DESCRIPTION
This removes the `VOLUME`s from the images.