### PR TITLE
Explicitly set --docker-network in ansible-test run

### DIFF
--- a/roles/build-ansible-test-images/tasks/test-image.yml
+++ b/roles/build-ansible-test-images/tasks/test-image.yml
@@ -30,7 +30,7 @@
           ignored_arguments = vault_password_files
 
 - name: Run a simple integration test using the image {{ item.name }}:{{ item.tag }} we built
-  command: "{{ images_venv }}/bin/ansible-test integration -v --python {{ item.python }} --docker {{ item.name }}:{{ item.tag }} ini_file"
+  command: "{{ images_venv }}/bin/ansible-test integration -v --python {{ item.python }} --docker-network podman --docker {{ item.name }}:{{ item.tag }} ini_file"
   args:
     chdir: "{{ _community_general }}"
   environment:


### PR DESCRIPTION
Subset of #31. If this makes CI pass again that would be great. Otherwise #31 is the next-best solution IMO.