### PR TITLE
centos-stream8: Add py3.6 and deprecate py3.8

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -20,7 +20,7 @@ jobs:
           - name: archlinux
             python: '3.10'
           - name: centos-stream8
-            python: '3.8'
+            python: '3.6'
           - name: debian-bullseye
             python: '3.9'
 

--- a/ansible-test/README.md
+++ b/ansible-test/README.md
@@ -50,7 +50,7 @@ dnf -y install podman buildah
 pip install ansible-core --user
 git clone https://github.com/ansible-collections/community.general ansible_collections/community/general
 cd ansible_collections/community/general
-ansible-test integration --python 3.8 --docker localhost/test-image:centos-stream8 ini_file
+ansible-test integration --python 3.6 --docker localhost/test-image:centos-stream8 ini_file
 ```
 
 ## Available images
@@ -58,8 +58,12 @@ ansible-test integration --python 3.8 --docker localhost/test-image:centos-strea
 | image             | py27 | py36 | py38 | py39 | py3.10 | Notes                                    |
 |-------------------|------|------|------|------|--------|------------------------------------------|
 | [archlinux]       |      |      |      |      |   ✔️    |                                          |
-| [centos-stream8]  |      |      |  ✔️   |      |        | Based on [centos8 ansible-test image]    |
+| [centos-stream8]  |      |  ✔️   |✔️[^1] |      |        | Based on [centos8 ansible-test image]    |
 | [debian-bullseye] |      |      |      |  ✔️   |        | Based on [ubuntu2004 ansible-test image] |
+
+
+[^1]: python3.8 support on centos-stream8 is DEPRECATED. It will be removed
+      from the image in a month or later without prior warning.
 
 Note that these images from only work with ansible-test from ansible-core 2.14.0 or later.
 

--- a/ansible-test/centos-stream8/dependencies.txt
+++ b/ansible-test/centos-stream8/dependencies.txt
@@ -17,6 +17,16 @@ openssh-clients
 openssh-server
 openssl-devel
 procps
+# python3.6 (default system interpreter)
+python3
+python3-cffi
+python3-cryptography
+python3-devel
+python3-lxml
+python3-pip
+python3-setuptools
+python3-wheel
+# python3.8 (DEPRECATED)
 python38
 python38-cffi
 python38-cryptography


### PR DESCRIPTION
Python 3.6 is the default system Python interpreter for CentOS Stream 8.
This is the interpreter that ansible-core discovers by default. Using
other Python interpreters to execute Ansible modules is unsupported.
Modules that don't use respawning[1] will not able to use Python
bindings for system libraries.

[1] https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/common/respawn.py

---

See https://github.com/ansible-collections/community.general/pull/5638 for more context.