### PR TITLE
Bump coverage to 6.5.0

### DIFF
--- a/ansible-test/archlinux/requirements.txt
+++ b/ansible-test/archlinux/requirements.txt
@@ -1,3 +1,3 @@
-coverage==4.5.4
+coverage==6.5.0
 # include ara for optional test and CI reporting
 ara

--- a/ansible-test/centos-stream8/build.sh
+++ b/ansible-test/centos-stream8/build.sh
@@ -16,9 +16,9 @@ buildah run "${build}" -- /bin/bash -c "localedef --no-archive -i en_US -f UTF-8
 # Extra python dependencies
 # python3.6 (default system interpreter)
 buildah run "${build}" -- /bin/bash -c "alternatives --set python3 /usr/bin/python3.6"
-buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.6 install -r /tmp/src/requirements.txt"
+buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.6 install -r /tmp/src/requirements-old.txt"
 # python3.8 (DEPRECATED)
-buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.8 install -r /tmp/src/requirements.txt"
+buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.8 install -r /tmp/src/requirements-old.txt"
 # python3.9
 buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.9 install -r /tmp/src/requirements.txt"
 

--- a/ansible-test/centos-stream8/requirements-old.txt
+++ b/ansible-test/centos-stream8/requirements-old.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+# include ara for optional test and CI reporting
+ara

--- a/ansible-test/centos-stream8/requirements.txt
+++ b/ansible-test/centos-stream8/requirements.txt
@@ -1,3 +1,3 @@
-coverage==4.5.4
+coverage==6.5.0
 # include ara for optional test and CI reporting
 ara

--- a/ansible-test/debian-bullseye/requirements.txt
+++ b/ansible-test/debian-bullseye/requirements.txt
@@ -1,4 +1,4 @@
-coverage==4.5.4
+coverage==6.5.0
 resolvelib==0.5.4
 # include ara for optional test and CI reporting
 ara


### PR DESCRIPTION
This is also used in the latest distro test images: https://github.com/ansible/distro-test-containers/blob/main/fedora37-test-container/requirements.txt