### PR TITLE
Remove Python 3.8 support from CentOS Stream 8

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -20,7 +20,7 @@ jobs:
           - name: archlinux
             python: '3.11'
           - name: centos-stream8
-            python: '3.6 3.8 3.9'
+            python: '3.6 3.9'
           - name: debian-bullseye
             python: '3.9'
 

--- a/ansible-test/README.md
+++ b/ansible-test/README.md
@@ -58,12 +58,9 @@ ansible-test integration --python 3.6 --docker localhost/test-image:centos-strea
 | image             | py27 | py36 | py38 | py39 | py3.10 | py3.11 | Notes                                    |
 |-------------------|------|------|------|------|--------|--------|------------------------------------------|
 | [archlinux]       |      |      |      |      |        |   ✔️    |                                          |
-| [centos-stream8]  |      |  ✔️   |✔️[^1] |  ✔️   |        |        | Based on [centos8 ansible-test image]    |
+| [centos-stream8]  |      |  ✔️   |      |  ✔️   |        |        | Based on [centos8 ansible-test image]    |
 | [debian-bullseye] |      |      |      |  ✔️   |        |        | Based on [ubuntu2004 ansible-test image] |
 
-
-[^1]: python3.8 support on centos-stream8 is DEPRECATED. It will be removed
-      from the image in a month or later without prior warning.
 
 Note that these images from only work with ansible-test from ansible-core 2.14.0 or later.
 

--- a/ansible-test/centos-stream8/build.sh
+++ b/ansible-test/centos-stream8/build.sh
@@ -17,8 +17,6 @@ buildah run "${build}" -- /bin/bash -c "localedef --no-archive -i en_US -f UTF-8
 # python3.6 (default system interpreter)
 buildah run "${build}" -- /bin/bash -c "alternatives --set python3 /usr/bin/python3.6"
 buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.6 install -r /tmp/src/requirements-old.txt"
-# python3.8 (DEPRECATED)
-buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.8 install -r /tmp/src/requirements-old.txt"
 # python3.9
 buildah run --volume ${SCRIPT_DIR}:/tmp/src:z "${build}" -- /bin/bash -c "pip3.9 install -r /tmp/src/requirements.txt"
 

--- a/ansible-test/centos-stream8/dependencies.txt
+++ b/ansible-test/centos-stream8/dependencies.txt
@@ -26,15 +26,6 @@ python3-lxml
 python3-pip
 python3-setuptools
 python3-wheel
-# python3.8 (DEPRECATED)
-python38
-python38-cffi
-python38-cryptography
-python38-devel
-python38-lxml
-python38-pip
-python38-setuptools
-python38-wheel
 # python3.9
 python39
 python39-cffi

--- a/roles/build-ansible-test-images/defaults/main.yml
+++ b/roles/build-ansible-test-images/defaults/main.yml
@@ -12,7 +12,6 @@ images_available:
     script: ansible-test/centos-stream8/build.sh
     pythons:
       - "3.6"
-      - "3.8"
       - "3.9"
   - name: localhost/test-image
     tag: debian-bullseye


### PR DESCRIPTION
Has been about time :)