### PR TITLE
Zuul: run tests with Docker instead of podman

### DIFF
--- a/roles/build-ansible-test-images/tasks/test-image-pythons.yml
+++ b/roles/build-ansible-test-images/tasks/test-image-pythons.yml
@@ -1,3 +1,6 @@
+- name: Push the container image {{ item.name }} to Docker
+  ansible.builtin.command: podman push {{ item.name }}:{{ item.tag }} docker-daemon:{{ item.name }}:{{ item.tag }}
+
 - name: Test the container image {{ item.name }}:{{ item.tag }} for Python versions
   include_tasks: test-image.yml
   loop: "{{ item.pythons }}"

--- a/roles/build-ansible-test-images/tasks/test-image.yml
+++ b/roles/build-ansible-test-images/tasks/test-image.yml
@@ -33,6 +33,6 @@
   command: "{{ images_venv }}/bin/ansible-test integration -v --python {{ item_python }} --docker-network podman --docker {{ item.name }}:{{ item.tag }} ini_file"
   args:
     chdir: "{{ _community_general }}"
-  environment:
-    ANSIBLE_TEST_PREFER_PODMAN: '1'
+  # environment:
+  #   ANSIBLE_TEST_PREFER_PODMAN: '1'
   when: images_test | bool


### PR DESCRIPTION
Let's see whether this also fixes Zuul (we did this in the past to fix GHA).

Would be a shame, but ...