### PR TITLE
Temporarily disable CentOS Stream 8 builds

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -20,8 +20,9 @@ jobs:
           # TODO: re-enable arch
           # - name: archlinux
           #   python: '3.10'
-          - name: centos-stream8
-            python: '3.6 3.8 3.9'
+          # TODO: re-enable CentOS Stream 8
+          # - name: centos-stream8
+          #   python: '3.6 3.8 3.9'
           - name: debian-bullseye
             python: '3.9'
 

--- a/ansible-test/README.md
+++ b/ansible-test/README.md
@@ -58,7 +58,7 @@ ansible-test integration --python 3.6 --docker localhost/test-image:centos-strea
 | image             | py27 | py36 | py38 | py39 | py3.10 | Notes                                    |
 |-------------------|------|------|------|------|--------|------------------------------------------|
 | [archlinux]       |      |      |      |      |   ✔️    | **Build temporarily disabled**           |
-| [centos-stream8]  |      |  ✔️   |✔️[^1] |  ✔️   |        | Based on [centos8 ansible-test image]    |
+| [centos-stream8]  |      |  ✔️   |✔️[^1] |  ✔️   |        | Based on [centos8 ansible-test image]; **Build temporarily disabled** |
 | [debian-bullseye] |      |      |      |  ✔️   |        | Based on [ubuntu2004 ansible-test image] |
 
 

--- a/roles/build-ansible-test-images/defaults/main.yml
+++ b/roles/build-ansible-test-images/defaults/main.yml
@@ -8,13 +8,14 @@ images_available:
   #   script: ansible-test/archlinux/build.sh
   #   pythons:
   #     - "3.10"
-  - name: localhost/test-image
-    tag: centos-stream8
-    script: ansible-test/centos-stream8/build.sh
-    pythons:
-      - "3.6"
-      - "3.8"
-      - "3.9"
+  # TODO: re-enable CentOS Stream 8
+  # - name: localhost/test-image
+  #   tag: centos-stream8
+  #   script: ansible-test/centos-stream8/build.sh
+  #   pythons:
+  #     - "3.6"
+  #     - "3.8"
+  #     - "3.9"
   - name: localhost/test-image
     tag: debian-bullseye
     script: ansible-test/debian-bullseye/build.sh


### PR DESCRIPTION
The tests currently do not want to run with podman or Docker on Zuul. Let's disable the builds for now so at least everything else can proceed.