### PR TITLE
CI: disable running tests with podman

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -67,6 +67,7 @@ jobs:
         env:
           ANSIBLE_TEST_PREFER_PODMAN: 1
         working-directory: ./.github/ansible-test-tests/ansible_collections/testns/testcol
+        if: false  # TODO: re-enable this once we figure out how to run tests with podman again...
 
       - name: Copy image from podman to docker
         run: |


### PR DESCRIPTION
They unfortunately fail for some time now, see https://github.com/ansible-community/images/actions/runs/8493232711/job/23267086510.