### PR TITLE
Zuul: force ansible-core 2.16 for tests

### DIFF
--- a/playbooks/build-ansible-test-images.yml
+++ b/playbooks/build-ansible-test-images.yml
@@ -20,3 +20,6 @@
     - name: Build ansible-test images
       include_role:
         name: build-ansible-test-images
+      vars:
+        images_ansible_name: ansible-core
+        images_ansible_version: '==2.16'

--- a/roles/build-ansible-test-images/tasks/install-ansible-test.yml
+++ b/roles/build-ansible-test-images/tasks/install-ansible-test.yml
@@ -40,8 +40,8 @@
 - name: Initialize virtual environment with the specified ansible(-core) package
   ansible.builtin.pip:
     name: "{{ images_ansible_name }}"
-    version: "{{ _install_ansible_version | default(omit, True) }}"
-    state: "{{ _install_ansible_state | default(omit, True) }}"
+    version: "{{ _install_ansible_version | default(omit, true) }}"
+    state: "{{ _install_ansible_state | default(omit, true) }}"
     virtualenv: "{{ images_venv }}"
     virtualenv_command: "{{ ansible_python.executable }} -m venv"
 


### PR DESCRIPTION
2.17 won't work with Python 3.6 anymore, needed for the CentOS 7 image.