### PR TITLE
Disable CentOS Stream 8 build

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,10 +21,10 @@ jobs:
             python: '3.12'
             ansible-core-1: ''
             ansible-core-2: devel
-          - name: centos-stream8
-            python: '3.6 3.9'
-            ansible-core-1: '==2.15'
-            ansible-core-2: stable-2.16
+#          - name: centos-stream8
+#            python: '3.6 3.9'
+#            ansible-core-1: '==2.15'
+#            ansible-core-2: stable-2.16
           - name: debian-bullseye
             python: '3.9'
             ansible-core-1: ''

--- a/playbooks/publish-ansible-test-images.yml
+++ b/playbooks/publish-ansible-test-images.yml
@@ -7,8 +7,8 @@
       # These images are meant to be provided by running the "build-ansible-test-images.yml" playbook.
       - name: localhost/test-image
         tag: archlinux
-      - name: localhost/test-image
-        tag: centos-stream8
+#      - name: localhost/test-image
+#        tag: centos-stream8
       - name: localhost/test-image
         tag: debian-bullseye
       - name: localhost/test-image

--- a/roles/build-ansible-test-images/defaults/main.yml
+++ b/roles/build-ansible-test-images/defaults/main.yml
@@ -7,12 +7,12 @@ images_available:
     script: ansible-test/archlinux/build.sh
     pythons:
       - "3.12"
-  - name: localhost/test-image
-    tag: centos-stream8
-    script: ansible-test/centos-stream8/build.sh
-    pythons:
-      - "3.6"
-      - "3.9"
+#  - name: localhost/test-image
+#    tag: centos-stream8
+#    script: ansible-test/centos-stream8/build.sh
+#    pythons:
+#      - "3.6"
+#      - "3.9"
   - name: localhost/test-image
     tag: debian-bullseye
     script: ansible-test/debian-bullseye/build.sh


### PR DESCRIPTION
It seems to be broken, as no packages can be installed anymore.

(If re-enabled, we'd need #77.)