### PR TITLE
Build CentOS Stream 8 image with modified yum baseurl

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,10 +21,10 @@ jobs:
             python: '3.12'
             ansible-core-1: ''
             ansible-core-2: devel
-#          - name: centos-stream8
-#            python: '3.6 3.9'
-#            ansible-core-1: '==2.15'
-#            ansible-core-2: stable-2.16
+          - name: centos-stream8
+            python: '3.6 3.9'
+            ansible-core-1: '==2.15'
+            ansible-core-2: stable-2.16
           - name: debian-bullseye
             python: '3.9'
             ansible-core-1: ''

--- a/ansible-test/centos-stream8/build.sh
+++ b/ansible-test/centos-stream8/build.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 DEPENDENCIES="$(cat ${SCRIPT_DIR}/dependencies.txt | grep -v '^#' | tr '\n' ' ')"
 
 build=$(buildah from quay.io/centos/centos:stream8)
+buildah run "${build}" -- /bin/bash -c 'sed -e "s/mirrorlist=/#mirrorlist=/g" -e "s/#baseurl=http:\/\/mirror.centos.org/baseurl=http:\/\/vault.centos.org/g" -i /etc/yum.repos.d/*.repo'
 buildah run "${build}" -- /bin/bash -c "dnf update -y && dnf install --allowerasing -y ${DEPENDENCIES} && dnf clean all"
 # Set
 

--- a/playbooks/publish-ansible-test-images.yml
+++ b/playbooks/publish-ansible-test-images.yml
@@ -7,8 +7,8 @@
       # These images are meant to be provided by running the "build-ansible-test-images.yml" playbook.
       - name: localhost/test-image
         tag: archlinux
-#      - name: localhost/test-image
-#        tag: centos-stream8
+      - name: localhost/test-image
+        tag: centos-stream8
       - name: localhost/test-image
         tag: debian-bullseye
       - name: localhost/test-image

--- a/roles/build-ansible-test-images/defaults/main.yml
+++ b/roles/build-ansible-test-images/defaults/main.yml
@@ -7,12 +7,12 @@ images_available:
     script: ansible-test/archlinux/build.sh
     pythons:
       - "3.12"
-#  - name: localhost/test-image
-#    tag: centos-stream8
-#    script: ansible-test/centos-stream8/build.sh
-#    pythons:
-#      - "3.6"
-#      - "3.9"
+  - name: localhost/test-image
+    tag: centos-stream8
+    script: ansible-test/centos-stream8/build.sh
+    pythons:
+      # - "3.6"  -- don't run tests
+      - "3.9"
   - name: localhost/test-image
     tag: debian-bullseye
     script: ansible-test/debian-bullseye/build.sh


### PR DESCRIPTION
Instead of straight away deleting it, let's build a last version that still allows to run `dnf install` etc.