### PR TITLE
CI: try to use a later Ubuntu image

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: 'Build ansible-test images (${{ matrix.name }} with Python ${{ matrix.python }})'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ubuntu-latest (22.04) has an ancient podman which can no longer talk to the Docker version used by GHA...