### PR TITLE
Arch Linux: make sure locale information provided by glibc is fully installed

### DIFF
--- a/ansible-test/archlinux/build.sh
+++ b/ansible-test/archlinux/build.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 DEPENDENCIES="$(cat ${SCRIPT_DIR}/dependencies.txt | tr '\n' ' ')"
 
 build=$(buildah from docker.io/library/archlinux:latest)
+
+buildah run "${build}" -- /bin/bash -c "sed -iE 's/^NoExtract.*locale.*$//g' /etc/pacman.conf"
 buildah run "${build}" -- /bin/bash -c "pacman -Syy && pacman-key --init && pacman -S archlinux-keyring --noconfirm && pacman -Su --noconfirm && pacman -S ${DEPENDENCIES} --noconfirm && pacman -Scc --noconfirm"
 
 # Disable PEP 668 marker

--- a/ansible-test/archlinux/dependencies.txt
+++ b/ansible-test/archlinux/dependencies.txt
@@ -5,6 +5,7 @@ coreutils
 file
 gcc
 git
+glibc
 iproute
 libffi
 make


### PR DESCRIPTION
Pacman is configured to not extract most locale information. Let's make it stop doing that.

Ref: https://github.com/ansible-collections/community.general/pull/9735