### PR TITLE
Add less to community-ee-[minimal,base] + test updates

### DIFF
--- a/execution-environments/community-ee-base/execution-environment.yml
+++ b/execution-environments/community-ee-base/execution-environment.yml
@@ -12,6 +12,7 @@ dependencies:
   system:
     - openssh-clients
     - sshpass
+    - less
   galaxy:
     collections:
     - name: ansible.posix

--- a/execution-environments/community-ee-base/tests.yml
+++ b/execution-environments/community-ee-base/tests.yml
@@ -33,6 +33,13 @@
       changed_when: false
       register: _ansible_version_pypi
 
+    - name: Installing less should be a no-op
+      become: true
+      ansible.builtin.package:  # noqa package-latest
+        name: less
+        state: latest
+      register: _installed_less
+
   tasks:
     - name: Validate image
       assert:
@@ -40,3 +47,4 @@
           - ansible_distribution == "Fedora"
           - ansible_distribution_release == ""
           - ansible_distribution_version | int >= 38
+          - _installed_less.changed == false

--- a/execution-environments/community-ee-base/tests.yml
+++ b/execution-environments/community-ee-base/tests.yml
@@ -15,21 +15,27 @@
 
     - name: Install ps
       become: true
-      ansible.builtin.package:
+      ansible.builtin.package:  # noqa package-latest
         name: procps-ng
         state: latest
 
     - name: Print running Ansible processes
-      ansible.builtin.shell: ps fauxwww | grep -i ansible
+      ansible.builtin.shell: |
+        set -o pipefail
+        ps fauxwww | grep -i ansible
       changed_when: false
 
     - name: Retrieve the installed version of ansible-core
-      ansible.builtin.shell: pip show ansible-core | awk "/Version/ {print $2}"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pip show ansible-core | awk "/Version/ {print $2}"
       changed_when: false
       register: _installed_ansible_core
 
     - name: Retrieve the installed version of ansible with pip
-      ansible.builtin.shell: pip show ansible | awk "/Version/ {print $2}"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pip show ansible | awk "/Version/ {print $2}"
       changed_when: false
       register: _ansible_version_pypi
 
@@ -42,7 +48,7 @@
 
   tasks:
     - name: Validate image
-      assert:
+      ansible.builtin.assert:
         that:
           - ansible_distribution == "Fedora"
           - ansible_distribution_release == ""

--- a/execution-environments/community-ee-base/tests.yml
+++ b/execution-environments/community-ee-base/tests.yml
@@ -25,19 +25,26 @@
         ps fauxwww | grep -i ansible
       changed_when: false
 
-    - name: Retrieve the installed version of ansible-core
+    - name: Retrieve the installed version of ansible-core with pip
       ansible.builtin.shell: |
         set -o pipefail
-        pip show ansible-core | awk "/Version/ {print $2}"
+        pip show ansible-core | awk '/^Version/ {print $2}'
       changed_when: false
       register: _installed_ansible_core
 
-    - name: Retrieve the installed version of ansible with pip
+    - name: Retrieve the installed version of ansible-runner with pip
       ansible.builtin.shell: |
         set -o pipefail
-        pip show ansible | awk "/Version/ {print $2}"
+        pip show ansible-runner | awk '/^Version/ {print $2}'
       changed_when: false
-      register: _ansible_version_pypi
+      register: _installed_ansible_runner
+
+    - name: Retrieve the installed version of ansible
+      ansible.builtin.shell: |
+        set -o pipefail
+        ansible --version | awk '/core/ { gsub("]",""); print $3 }'
+      changed_when: false
+      register: _ansible_version
 
     - name: Installing less should be a no-op
       become: true
@@ -53,4 +60,6 @@
           - ansible_distribution == "Fedora"
           - ansible_distribution_release == ""
           - ansible_distribution_version | int >= 38
+          - _installed_ansible_core.stdout == _ansible_version.stdout
+          - _installed_ansible_runner.stdout is version('2.4.1', '>=')
           - _installed_less.changed == false

--- a/execution-environments/community-ee-minimal/execution-environment.yml
+++ b/execution-environments/community-ee-minimal/execution-environment.yml
@@ -12,6 +12,7 @@ dependencies:
   system:
     - openssh-clients
     - sshpass
+    - less
 
 additional_build_steps:
   prepend_base:

--- a/execution-environments/community-ee-minimal/tests.yml
+++ b/execution-environments/community-ee-minimal/tests.yml
@@ -15,34 +15,40 @@
 
     - name: Install ps
       become: true
-      ansible.builtin.package:
+      ansible.builtin.package:  # noqa package-latest
         name: procps-ng
         state: latest
 
     - name: Print running Ansible processes
-      ansible.builtin.shell: ps fauxwww | grep -i ansible
+      ansible.builtin.shell: |
+        set -o pipefail
+        ps fauxwww | grep -i ansible
       changed_when: false
 
     - name: Retrieve the installed version of ansible-core
-      ansible.builtin.shell: pip show ansible-core | awk "/Version/ {print $2}"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pip show ansible-core | awk "/Version/ {print $2}"
       changed_when: false
       register: _installed_ansible_core
 
     - name: Retrieve the installed version of ansible with pip
-      ansible.builtin.shell: pip show ansible | awk "/Version/ {print $2}"
+      ansible.builtin.shell: |
+        set -o pipefail
+        pip show ansible | awk "/Version/ {print $2}"
       changed_when: false
       register: _ansible_version_pypi
 
     - name: Installing less should be a no-op
       become: true
-      ansible.builtin.package:
+      ansible.builtin.package:  # noqa package-latest
         name: less
         state: latest
       register: _installed_less
 
   tasks:
     - name: Validate image
-      assert:
+      ansible.builtin.assert:
         that:
           - ansible_distribution == "Fedora"
           - ansible_distribution_release == ""

--- a/execution-environments/community-ee-minimal/tests.yml
+++ b/execution-environments/community-ee-minimal/tests.yml
@@ -25,19 +25,26 @@
         ps fauxwww | grep -i ansible
       changed_when: false
 
-    - name: Retrieve the installed version of ansible-core
+    - name: Retrieve the installed version of ansible-core with pip
       ansible.builtin.shell: |
         set -o pipefail
-        pip show ansible-core | awk "/Version/ {print $2}"
+        pip show ansible-core | awk '/^Version/ {print $2}'
       changed_when: false
       register: _installed_ansible_core
 
-    - name: Retrieve the installed version of ansible with pip
+    - name: Retrieve the installed version of ansible-runner with pip
       ansible.builtin.shell: |
         set -o pipefail
-        pip show ansible | awk "/Version/ {print $2}"
+        pip show ansible-runner | awk '/^Version/ {print $2}'
       changed_when: false
-      register: _ansible_version_pypi
+      register: _installed_ansible_runner
+
+    - name: Retrieve the installed version of ansible
+      ansible.builtin.shell: |
+        set -o pipefail
+        ansible --version | awk '/core/ { gsub("]",""); print $3 }'
+      changed_when: false
+      register: _ansible_version
 
     - name: Installing less should be a no-op
       become: true
@@ -53,4 +60,6 @@
           - ansible_distribution == "Fedora"
           - ansible_distribution_release == ""
           - ansible_distribution_version | int >= 38
+          - _installed_ansible_core.stdout == _ansible_version.stdout
+          - _installed_ansible_runner.stdout is version('2.4.1', '>=')
           - _installed_less.changed == false

--- a/execution-environments/community-ee-minimal/tests.yml
+++ b/execution-environments/community-ee-minimal/tests.yml
@@ -33,6 +33,13 @@
       changed_when: false
       register: _ansible_version_pypi
 
+    - name: Installing less should be a no-op
+      become: true
+      ansible.builtin.package:
+        name: less
+        state: latest
+      register: _installed_less
+
   tasks:
     - name: Validate image
       assert:
@@ -40,3 +47,4 @@
           - ansible_distribution == "Fedora"
           - ansible_distribution_release == ""
           - ansible_distribution_version | int >= 38
+          - _installed_less.changed == false


### PR DESCRIPTION
# Description

This PR:
  1. Adds `less` to the community-ee-minimal and community-ee-base images to resolve the issue of `ansible-navigator config list` not working with `--mode stdout` (with new test).
  2. Update tests to appease `ansible-lint`.
  3. Fixed broken Ansible version tests in community-ee-minimal and community-ee-base (exposed by adding `set -o pipefail` to appease `ansible-lint`) and enhance the `asserts`.

# Testing

## TL;DR : All tests pass for community-ee-base and community-ee-minimal

   <details><summary><i>community-ee-base</i></summary>
   
   ![image](https://github.com/user-attachments/assets/9bbd814f-8d98-4a49-9450-e3e789b88e52)
   </details>

   <details><summary><i>community-ee-minimal</i></summary>
   
   ![image](https://github.com/user-attachments/assets/93d2b153-6111-4f0d-ad26-435bdf6f07bf)
   </details>

---
## Adding `less` to community-ee-base and community-ee-minimal images

### Problem: Running `ansible-navigator config list` with `--mode stdout` fails due to `less: command not found`:

   <details><summary><i>community-ee-minimal</i></summary>
   
   ```bash
   ansible-navigator config list --pp missing --eei ghcr.io/ansible-community/community-ee-minimal:latest --mode stdout
   ```
   
   ![image](https://github.com/user-attachments/assets/3c8241c2-af42-4f34-bb43-19385db3076e)
   </details>

   <details><summary><i>community-ee-base</i></summary>
   
   ```bash
   ansible-navigator config list --pp missing --eei ghcr.io/ansible-community/community-ee-base:latest --mode stdout
   ```

   ![image](https://github.com/user-attachments/assets/8f41e76c-55ac-4d34-bac0-26c6f74afc34)
   </details>

### Solution: Add `less` to community-ee-minimal and community-ee-base

(_NOTE: I *LOVE* that minimal images exist, and I feel bad adding to them, but I think the products these support should *work* with the images_). 
   
   <details><summary><i>community-ee-minimal builds && ansible-navigator config list works with stdout</i></summary>
   
   ```bash
   ansible-navigator config list --pp never --eei community-ee-minimal:add-less --mode stdout
   ```

   ![Screenshot from 2025-04-14 11-06-00](https://github.com/user-attachments/assets/632f4447-06a9-4d20-a22b-63655c437128)
   </details>

   <details><summary><i>community-ee-base builds && ansible-navigator config list works with stdout</i></summary>
   
   ```bash
   ansible-navigator config list --pp never --eei community-ee-base:add-less --mode stdout
   ```

   ![Screenshot from 2025-04-14 12-16-26](https://github.com/user-attachments/assets/1f33be07-023c-486d-b669-5f114787b292)
   </details>

## Appeasing ansible-lint for community-ee-[base,minimal] tests

### Problem: ansible-lint fails

   <details><summary><i>community-ee-minimal ansible-lint failures</i></summary>

   ![Screenshot from 2025-04-14 11-59-27](https://github.com/user-attachments/assets/a79f71d4-7132-4c05-b878-380f07a4edcd)
   </details>

   <details><summary><i>community-ee-base ansible-lint failures</i></summary>
   
   ![Screenshot from 2025-04-14 12-23-49](https://github.com/user-attachments/assets/2b698d2f-a9f5-4e48-8f55-b54954681984)
   </details>

### Solution: Use FQDNs, ignore package latest warning, set pipefail option in shell

   <details><summary><i>community-ee-minimal ansible-lint appeased</i></summary>

   ![Screenshot from 2025-04-14 12-00-58](https://github.com/user-attachments/assets/fc8c9d1e-0c99-4e54-a78e-77dfe926aa63)
   </details>

   <details><summary><i>community-ee-base ansible-lint appeased</i></summary>

   ![Screenshot from 2025-04-14 12-24-03](https://github.com/user-attachments/assets/b8cee68f-9fac-4ecf-abba-bdf093738c7b)
   </details>

## Fix and enhance community-ee-[base,minimal] tests

### Problem: Adding the pipefail option to the shell test exposed that one of the pre-tasks was actually failing

   <details>

   ![Screenshot from 2025-04-14 13-29-40](https://github.com/user-attachments/assets/774f20fe-4b30-4cd1-9aa0-34ee4913bdac)
   </details>

### Solution: Switch from `pip show ansible` to `ansible --version` / Enhancement: Assert version matches `ansible-core` version

   <details>

   ![Screenshot from 2025-04-14 14-10-56](https://github.com/user-attachments/assets/948eea0f-f4fb-41ef-be25-fbc324d9f31e)
   ![Screenshot from 2025-04-14 14-09-23](https://github.com/user-attachments/assets/7d0eafca-8eb5-4c7e-96da-7b47a98de039)

   </details>

---
### Problem: Running tests in verbose mode exposed that the `awk` was not pulling only version numbers

   <details><summary>Using double quotes with `awk` results in unintentional shell expansion of unset variable `$2` resulting in the entire line being output</summary>

   ![Screenshot from 2025-04-14 13-26-02](https://github.com/user-attachments/assets/d1814bf0-578e-433b-bcb3-8d94b2f8c202)
   </details>

### Solution: Using single quotes with `awk`

   <details>

   ![Screenshot from 2025-04-14 14-07-09](https://github.com/user-attachments/assets/0e49eba0-0441-4093-8d48-0692cb0480e8)
   </details>

---
### Enhancement: Add a check for `ansible-runner`

I figured since it is being added to the image, and y'all had some existing version check tests, I'd reappropriate the old task for `pip show ansible` with `pip show ansible-runner` and assert that it is `>=` the version that the container currently contains.

   <details>

   ![Screenshot from 2025-04-14 14-08-29](https://github.com/user-attachments/assets/c5987049-99c9-4005-8ea9-004747ac3e3b)
   </details>