### PR TITLE
Updates ansible-core version 2.18.8-1 community-ee

### DIFF
--- a/execution-environments/community-ee-base/execution-environment.yml
+++ b/execution-environments/community-ee-base/execution-environment.yml
@@ -6,7 +6,7 @@ images:
     name: quay.io/fedora/fedora:42
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.18.7
+    package_pip: ansible-core==2.18.8
   ansible_runner:
     package_pip: ansible-runner
   system:

--- a/execution-environments/community-ee-minimal/execution-environment.yml
+++ b/execution-environments/community-ee-minimal/execution-environment.yml
@@ -6,7 +6,7 @@ images:
     name: quay.io/fedora/fedora:42
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.18.7
+    package_pip: ansible-core==2.18.8
   ansible_runner:
     package_pip: ansible-runner
   system:


### PR DESCRIPTION
Edits the `ansible-core` version to **2.18.8** for `community ee base` & `community-ee-minimal` version **2.18.8-1** release.