### PR TITLE
Updates fedora version to 42 & core 2.19.4

### DIFF
--- a/execution-environments/community-ee-base/execution-environment.yml
+++ b/execution-environments/community-ee-base/execution-environment.yml
@@ -3,10 +3,10 @@
 version: 3
 images:
   base_image:
-    name: quay.io/fedora/fedora:42
+    name: quay.io/fedora/fedora:43
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.19.3
+    package_pip: ansible-core==2.19.4
   ansible_runner:
     package_pip: ansible-runner
   system:

--- a/execution-environments/community-ee-minimal/execution-environment.yml
+++ b/execution-environments/community-ee-minimal/execution-environment.yml
@@ -3,10 +3,10 @@
 version: 3
 images:
   base_image:
-    name: quay.io/fedora/fedora:42
+    name: quay.io/fedora/fedora:43
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.19.3
+    package_pip: ansible-core==2.19.4
   ansible_runner:
     package_pip: ansible-runner
   system:


### PR DESCRIPTION
Updates fedora and ansible core for ee 2.19.4-1 version release : 

- fedora version to 42 

- ansible-core version to  2.19.4