### PR TITLE
Updates core,collection & fedora versions for Base and Minimal

### DIFF
--- a/execution-environments/community-ee-base/execution-environment.yml
+++ b/execution-environments/community-ee-base/execution-environment.yml
@@ -3,10 +3,10 @@
 version: 3
 images:
   base_image:
-    name: quay.io/fedora/fedora:43
+    name: quay.io/fedora/fedora:44
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.20.4
+    package_pip: ansible-core==2.20.5
   ansible_runner:
     package_pip: ansible-runner
   system:
@@ -18,7 +18,7 @@ dependencies:
     - name: ansible.posix
       version: 2.1.0
     - name: ansible.utils
-      version: 6.0.1
+      version: 6.0.2
     - name: ansible.windows
       version: 3.5.0
 

--- a/execution-environments/community-ee-minimal/execution-environment.yml
+++ b/execution-environments/community-ee-minimal/execution-environment.yml
@@ -3,10 +3,10 @@
 version: 3
 images:
   base_image:
-    name: quay.io/fedora/fedora:43
+    name: quay.io/fedora/fedora:44
 dependencies:
   ansible_core:
-    package_pip: ansible-core==2.20.4
+    package_pip: ansible-core==2.20.5
   ansible_runner:
     package_pip: ansible-runner
   system:


### PR DESCRIPTION
Updates the following :

- ansible-core - 2.20.5
-  fedora - 44
- collection: `ansible.utils` : 6.0.2


