### PR TITLE
Use more up-to-date Arch Linux image from ghcr.io

### DIFF
--- a/ansible-test/archlinux/build.sh
+++ b/ansible-test/archlinux/build.sh
@@ -6,7 +6,8 @@ set -ex
 SCRIPT_DIR=$(cd `dirname $0` && pwd -P)
 DEPENDENCIES="$(cat ${SCRIPT_DIR}/dependencies.txt | tr '\n' ' ')"
 
-build=$(buildah from docker.io/library/archlinux:latest)
+# https://gitlab.archlinux.org/archlinux/archlinux-docker
+build=$(buildah from ghcr.io/archlinux/archlinux:latest)
 
 buildah run "${build}" -- /bin/bash -c "sed -iE 's/^NoExtract.*locale.*$//g' /etc/pacman.conf"
 buildah run "${build}" -- /bin/bash -c "pacman -Syy && pacman-key --init && pacman -S archlinux-keyring --noconfirm && pacman -Su --noconfirm && pacman -S ${DEPENDENCIES} --noconfirm && pacman -Scc --noconfirm"


### PR DESCRIPTION
The docker.io image is only updated once per week, the others daily. Since we're building our image with GHA, using ghcr.io is best.