### PR TITLE
replace deprecated ansible_ variables in tests.yml

### DIFF
--- a/execution-environments/community-ee-base/tests.yml
+++ b/execution-environments/community-ee-base/tests.yml
@@ -57,9 +57,9 @@
     - name: Validate image
       ansible.builtin.assert:
         that:
-          - ansible_distribution == "Fedora"
-          - ansible_distribution_release == ""
-          - ansible_distribution_version | int >= 38
+          - ansible_facts.distribution == "Fedora"
+          - ansible_facts.distribution_release == ""
+          - ansible_facts.distribution_version | int >= 38
           - _installed_ansible_core.stdout == _ansible_version.stdout
           - _installed_ansible_runner.stdout is version('2.4.1', '>=')
           - _installed_less.changed == false

--- a/execution-environments/community-ee-minimal/tests.yml
+++ b/execution-environments/community-ee-minimal/tests.yml
@@ -57,9 +57,9 @@
     - name: Validate image
       ansible.builtin.assert:
         that:
-          - ansible_distribution == "Fedora"
-          - ansible_distribution_release == ""
-          - ansible_distribution_version | int >= 38
+          - ansible_facts.distribution == "Fedora"
+          - ansible_facts.distribution_release == ""
+          - ansible_facts.distribution_version | int >= 38
           - _installed_ansible_core.stdout == _ansible_version.stdout
           - _installed_ansible_runner.stdout is version('2.4.1', '>=')
           - _installed_less.changed == false


### PR DESCRIPTION
reoplace variables in order to satisfy the warning

```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
```